### PR TITLE
Exception improvements

### DIFF
--- a/pgoapi/__init__.py
+++ b/pgoapi/__init__.py
@@ -41,7 +41,7 @@ protobuf_version = 0
 try:
     protobuf_version = pkg_resources.get_distribution("protobuf").version
     protobuf_exist = True
-except:
+except Exception:
     pass
 
 if (not protobuf_exist) or (int(protobuf_version[:1]) < 3):
@@ -61,5 +61,5 @@ logging.getLogger("auth_google").addHandler(logging.NullHandler())
 try:
     import requests.packages.urllib3
     requests.packages.urllib3.disable_warnings()
-except:
+except Exception:
     pass

--- a/pgoapi/auth_google.py
+++ b/pgoapi/auth_google.py
@@ -25,12 +25,12 @@ Author: tjado <https://github.com/tejado>
 
 from __future__ import absolute_import
 
-import six
 import logging
 
 from pgoapi.auth import Auth
-from pgoapi.exceptions import AuthException
+from pgoapi.exceptions import AuthException, InvalidCredentialsException
 from gpsoauth import perform_master_login, perform_oauth
+from six import string_types
 
 class AuthGoogle(Auth):
 
@@ -52,8 +52,8 @@ class AuthGoogle(Auth):
     def user_login(self, username, password):
         self.log.info('Google User Login for: {}'.format(username))
 
-        if not isinstance(username, six.string_types) or not isinstance(password, six.string_types):
-            raise AuthException("Username/password not correctly specified")
+        if not isinstance(username, string_types) or not isinstance(password, string_types):
+            raise InvalidCredentialsException("Username/password not correctly specified")
 
         user_login = perform_master_login(username, password, self.GOOGLE_LOGIN_ANDROID_ID, proxy=self._proxy)
 

--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -28,16 +28,16 @@ from future.standard_library import install_aliases
 install_aliases()
 
 import re
-import six
 import json
 import logging
 import requests
 
 from urllib.parse import parse_qs
+from six import string_types
 
 from pgoapi.auth import Auth
 from pgoapi.utilities import get_time
-from pgoapi.exceptions import AuthException
+from pgoapi.exceptions import AuthException, InvalidCredentialsException
 
 from requests.exceptions import ConnectionError
 
@@ -61,8 +61,8 @@ class AuthPtc(Auth):
     def user_login(self, username, password):
         self.log.info('PTC User Login for: {}'.format(username))
 
-        if not isinstance(username, six.string_types) or not isinstance(password, six.string_types):
-            raise AuthException("Username/password not correctly specified")
+        if not isinstance(username, string_types) or not isinstance(password, string_types):
+            raise InvalidCredentialsException("Username/password not correctly specified")
 
         head = {'User-Agent': 'niantic'}
 

--- a/pgoapi/exceptions.py
+++ b/pgoapi/exceptions.py
@@ -23,37 +23,97 @@ OR OTHER DEALINGS IN THE SOFTWARE.
 Author: tjado <https://github.com/tejado>
 """
 
-class AuthException(Exception):
-    pass
 
-class NotLoggedInException(Exception):
-    pass
+class PgoapiError(Exception):
+    """Any custom exception in this module"""
 
-class ServerBusyOrOfflineException(Exception):
-    pass
+class HashServerException(PgoapiError):
+    """Parent class of all hashing server errors"""
 
-class PleaseInstallProtobufVersion3(Exception):
-    pass
 
-class NoPlayerPositionSetException(Exception):
-    pass
-    
-class EmptySubrequestChainException(Exception):
-    pass
-    
-class ServerSideRequestThrottlingException(Exception):
-    pass
+class AuthException(PgoapiError):
+    """Raised when logging in fails"""
 
-class ServerSideAccessForbiddenException(Exception):
-    pass
+class InvalidCredentialsException(AuthException, ValueError):
+    """Raised when the username, password, or provider are empty/invalid"""
 
-class UnexpectedResponseException(Exception):
-    pass
 
-class AuthTokenExpiredException(Exception):
-    pass
+class AuthTokenExpiredException(PgoapiError):
+    """Raised when your auth token has expired (code 102)"""
 
-class ServerApiEndpointRedirectException(Exception):
+
+class BadRequestException(PgoapiError):
+    """Raised when HTTP code 400 is returned"""
+
+class BadHashRequestException(BadRequestException):
+    """Raised when hashing server returns code 400"""
+
+
+class BannedAccountException(PgoapiError):
+    """Raised when an account is banned"""
+
+
+class MalformedResponseException(PgoapiError):
+    """Raised when the response is empty or not in an expected format"""
+
+class MalformedNianticResponseException(PgoapiError):
+    """Raised when a Niantic response is empty or not in an expected format"""
+
+class MalformedHashResponseException(MalformedResponseException, HashServerException):
+    """Raised when the response from the hash server cannot be parsed."""
+
+
+class NoPlayerPositionSetException(PgoapiError, ValueError):
+    """Raised when either lat or lng is None"""
+
+
+class NotLoggedInException(PgoapiError):
+    """Raised when attempting to make a request while not authenticated"""
+
+
+class ServerBusyOrOfflineException(PgoapiError):
+    """Raised when unable to establish a connection with a server"""
+
+class NianticOfflineException(ServerBusyOrOfflineException):
+    """Raised when unable to establish a conection with Niantic"""
+
+class HashingOfflineException(ServerBusyOrOfflineException, HashServerException):
+    """Raised when unable to establish a conection with the hashing server"""
+
+
+class PleaseInstallProtobufVersion3(PgoapiError):
+    """Raised when Protobuf is unavailable or too old"""
+
+
+class ServerSideAccessForbiddenException(PgoapiError):
+    """Raised when access to a server is forbidden"""
+
+class NianticIPBannedException(ServerSideAccessForbiddenException):
+    """Raised when Niantic returns a 403, meaning your IP is probably banned"""
+
+class HashingForbiddenException(ServerSideAccessForbiddenException, HashServerException):
+    """Raised when the hashing server returns 401 or 403"""
+
+
+class ServerSideRequestThrottlingException(PgoapiError):
+    """Raised when too many requests were made in a short period"""
+
+class NianticThrottlingException(ServerSideRequestThrottlingException):
+    """Raised when too many requests to Niantic were made in a short period"""
+
+class HashingQuotaExceededException(ServerSideRequestThrottlingException, HashServerException):
+    """Raised when you exceed your hashing server quota"""
+
+
+class UnexpectedResponseException(PgoapiError):
+    """Raised when an unhandled HTTP status code is received"""
+
+class UnexpectedHashResponseException(UnexpectedResponseException, HashServerException):
+    """Raised when an unhandled HTTP code is received from the hash server"""
+
+
+class ServerApiEndpointRedirectException(PgoapiError):
+    """Raised when the API redirects you to another endpoint"""
     def __init__(self):
         self._api_endpoint = None
 


### PR DESCRIPTION
Created a PgoapiException parent class that all custom exceptions
inherit, created a HashingServerException parent class that all hashing
server exceptions inherit, added docstrings for all exceptions, added
some new exception variants to distinguish between errors from
communicating with Niantic and the hashing server, added
InvalidCredentialsException to distinguish between errors from invalid
user input and problems from the login process, added a
BadRequestException for 400 errors, added MalformedResponseException
for invalid and empty server responses, added
HashingQuotaExceededException for when the hash key is exhausted, check
for more HTTP status codes, change some `is not None` tests to plain
truth tests in some cases where no valid values would fail, raised the
level of some error logging, replaced some empty exception handlers
with `except Exception` to prevent catching things like
KeyboardInterrupts, remove unused EmptySubrequestChainException, added
BannedAccountException.