### PR TITLE
Prevent updates to pre-release protobufs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 geopy==1.11.0
-protobuf>=3.0.0a3
+protobuf>=3.0.0
 requests==2.10.0
 s2sphere==0.2.4
 gpsoauth==0.4.0


### PR DESCRIPTION
Since a pre-release version was specified in requirements.txt for
protobuf, pip assumed that it should update to any pre-release version
like protobuf 3.2.0rc1.